### PR TITLE
Add simple compiler skeleton with lexer stage

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -1,0 +1,11 @@
+CXX=g++
+CXXFLAGS=-std=c++17 -Wall -Wextra -Iinclude
+
+SRC=$(wildcard src/*.cpp)
+OBJ=$(SRC:.cpp=.o)
+
+compiler: $(OBJ)
+	$(CXX) $(CXXFLAGS) -o $@ $^
+
+clean:
+	rm -f src/*.o compiler

--- a/compiler/include/ast.hpp
+++ b/compiler/include/ast.hpp
@@ -1,0 +1,10 @@
+#ifndef AST_HPP
+#define AST_HPP
+
+namespace mylang {
+
+// AST node definitions will be added later
+
+} // namespace mylang
+
+#endif // AST_HPP

--- a/compiler/include/lexer.hpp
+++ b/compiler/include/lexer.hpp
@@ -1,0 +1,28 @@
+#ifndef LEXER_HPP
+#define LEXER_HPP
+
+#include <string>
+#include <vector>
+#include "token.hpp"
+
+namespace mylang {
+
+class Lexer {
+public:
+    explicit Lexer(const std::string &source);
+    std::vector<Token> tokenize();
+
+private:
+    char peek() const;
+    char advance();
+    bool match(char expected);
+    void skipWhitespace();
+    Token makeToken(TokenType type, const std::string &lexeme);
+
+    const std::string &source;
+    size_t current{0};
+};
+
+} // namespace mylang
+
+#endif // LEXER_HPP

--- a/compiler/include/parser.hpp
+++ b/compiler/include/parser.hpp
@@ -1,0 +1,12 @@
+#ifndef PARSER_HPP
+#define PARSER_HPP
+
+namespace mylang {
+
+class Parser {
+    // Parser implementation will go here
+};
+
+} // namespace mylang
+
+#endif // PARSER_HPP

--- a/compiler/include/token.hpp
+++ b/compiler/include/token.hpp
@@ -1,0 +1,33 @@
+#ifndef TOKEN_HPP
+#define TOKEN_HPP
+
+#include <string>
+
+namespace mylang {
+
+enum class TokenType {
+    // Single-character tokens
+    LEFT_PAREN, RIGHT_PAREN,
+    LEFT_BRACE, RIGHT_BRACE,
+    SEMICOLON,
+    PLUS, MINUS, STAR, SLASH,
+    EQUAL,
+
+    // Literals
+    IDENTIFIER, NUMBER, STRING,
+
+    // Keywords
+    KW_INT, KW_RETURN,
+
+    END_OF_FILE,
+    INVALID
+};
+
+struct Token {
+    TokenType type;
+    std::string lexeme;
+};
+
+} // namespace mylang
+
+#endif // TOKEN_HPP

--- a/compiler/src/lexer.cpp
+++ b/compiler/src/lexer.cpp
@@ -1,0 +1,83 @@
+#include "lexer.hpp"
+#include <cctype>
+
+namespace mylang {
+
+Lexer::Lexer(const std::string &src) : source(src) {}
+
+char Lexer::peek() const {
+    if (current >= source.size()) return '\0';
+    return source[current];
+}
+
+char Lexer::advance() {
+    if (current >= source.size()) return '\0';
+    return source[current++];
+}
+
+bool Lexer::match(char expected) {
+    if (peek() == expected) {
+        current++;
+        return true;
+    }
+    return false;
+}
+
+void Lexer::skipWhitespace() {
+    while (std::isspace(peek())) {
+        current++;
+    }
+}
+
+Token Lexer::makeToken(TokenType type, const std::string &lexeme) {
+    return Token{type, lexeme};
+}
+
+std::vector<Token> Lexer::tokenize() {
+    std::vector<Token> tokens;
+
+    while (current < source.size()) {
+        skipWhitespace();
+        char c = peek();
+        size_t start = current;
+
+        if (std::isalpha(c) || c == '_') {
+            while (std::isalnum(peek()) || peek() == '_') advance();
+            std::string text = source.substr(start, current - start);
+            if (text == "int") {
+                tokens.push_back(makeToken(TokenType::KW_INT, text));
+            } else if (text == "return") {
+                tokens.push_back(makeToken(TokenType::KW_RETURN, text));
+            } else {
+                tokens.push_back(makeToken(TokenType::IDENTIFIER, text));
+            }
+            continue;
+        }
+
+        if (std::isdigit(c)) {
+            while (std::isdigit(peek())) advance();
+            std::string text = source.substr(start, current - start);
+            tokens.push_back(makeToken(TokenType::NUMBER, text));
+            continue;
+        }
+
+        switch (advance()) {
+            case '(': tokens.push_back(makeToken(TokenType::LEFT_PAREN, "(")); break;
+            case ')': tokens.push_back(makeToken(TokenType::RIGHT_PAREN, ")")); break;
+            case '{': tokens.push_back(makeToken(TokenType::LEFT_BRACE, "{")); break;
+            case '}': tokens.push_back(makeToken(TokenType::RIGHT_BRACE, "}")); break;
+            case ';': tokens.push_back(makeToken(TokenType::SEMICOLON, ";")); break;
+            case '+': tokens.push_back(makeToken(TokenType::PLUS, "+")); break;
+            case '-': tokens.push_back(makeToken(TokenType::MINUS, "-")); break;
+            case '*': tokens.push_back(makeToken(TokenType::STAR, "*")); break;
+            case '/': tokens.push_back(makeToken(TokenType::SLASH, "/")); break;
+            case '=': tokens.push_back(makeToken(TokenType::EQUAL, "=")); break;
+            default: tokens.push_back(makeToken(TokenType::INVALID, std::string(1, c))); break;
+        }
+    }
+
+    tokens.push_back(makeToken(TokenType::END_OF_FILE, ""));
+    return tokens;
+}
+
+} // namespace mylang

--- a/compiler/src/main.cpp
+++ b/compiler/src/main.cpp
@@ -1,0 +1,30 @@
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include "lexer.hpp"
+
+using namespace mylang;
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <source file>\n";
+        return 1;
+    }
+    std::ifstream file(argv[1]);
+    if (!file) {
+        std::cerr << "Could not open file: " << argv[1] << "\n";
+        return 1;
+    }
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    std::string source = buffer.str();
+
+    Lexer lexer(source);
+    auto tokens = lexer.tokenize();
+
+    for (const auto &tok : tokens) {
+        std::cout << static_cast<int>(tok.type) << "\t" << tok.lexeme << "\n";
+    }
+
+    return 0;
+}

--- a/compiler/src/parser.cpp
+++ b/compiler/src/parser.cpp
@@ -1,0 +1,5 @@
+#include "parser.hpp"
+
+namespace mylang {
+// Parser implementation will be added later
+}


### PR DESCRIPTION
## Summary
- set up `compiler/` directory layout with headers and sources
- create a basic Makefile
- implement `Lexer` class that tokenizes keywords, identifiers, numbers and symbols
- minimal `main.cpp` to run lexer and print tokens

## Testing
- `make`
- `./compiler sample.my`

------
https://chatgpt.com/codex/tasks/task_e_6843cd1d7af88324bc8c58104a73e696