### PR TITLE
Add parser and AST with dumping capability

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -1,0 +1,11 @@
+CXX=g++
+CXXFLAGS=-std=c++17 -Wall -Wextra -Iinclude
+
+SRC=$(wildcard src/*.cpp)
+OBJ=$(SRC:.cpp=.o)
+
+compiler: $(OBJ)
+	$(CXX) $(CXXFLAGS) -o $@ $^
+
+clean:
+	rm -f src/*.o compiler

--- a/compiler/include/ast.hpp
+++ b/compiler/include/ast.hpp
@@ -1,0 +1,78 @@
+#ifndef AST_HPP
+#define AST_HPP
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace mylang {
+
+// Forward declarations
+struct Stmt;
+struct Expr;
+struct BlockStmt;
+struct FunctionDecl;
+
+using StmtPtr = std::unique_ptr<Stmt>;
+using ExprPtr = std::unique_ptr<Expr>;
+
+struct ASTNode {
+    virtual ~ASTNode() = default;
+    virtual void dump(int indent = 0) const = 0;
+};
+
+struct Expr : ASTNode {};
+struct Stmt : ASTNode {};
+
+struct Program : ASTNode {
+    std::vector<std::unique_ptr<FunctionDecl>> functions;
+    void dump(int indent = 0) const override;
+};
+
+struct FunctionDecl : ASTNode {
+    std::string name;
+    std::unique_ptr<BlockStmt> body;
+    void dump(int indent = 0) const override;
+};
+
+struct BlockStmt : Stmt {
+    std::vector<StmtPtr> statements;
+    void dump(int indent = 0) const override;
+};
+
+struct VarDecl : Stmt {
+    std::string name;
+    ExprPtr init;
+    void dump(int indent = 0) const override;
+};
+
+struct ReturnStmt : Stmt {
+    ExprPtr value;
+    void dump(int indent = 0) const override;
+};
+
+struct ExprStmt : Stmt {
+    ExprPtr expr;
+    void dump(int indent = 0) const override;
+};
+
+struct BinaryExpr : Expr {
+    std::string op;
+    ExprPtr left;
+    ExprPtr right;
+    void dump(int indent = 0) const override;
+};
+
+struct Identifier : Expr {
+    std::string name;
+    void dump(int indent = 0) const override;
+};
+
+struct Literal : Expr {
+    std::string value;
+    void dump(int indent = 0) const override;
+};
+
+} // namespace mylang
+
+#endif // AST_HPP

--- a/compiler/include/lexer.hpp
+++ b/compiler/include/lexer.hpp
@@ -1,0 +1,28 @@
+#ifndef LEXER_HPP
+#define LEXER_HPP
+
+#include <string>
+#include <vector>
+#include "token.hpp"
+
+namespace mylang {
+
+class Lexer {
+public:
+    explicit Lexer(const std::string &source);
+    std::vector<Token> tokenize();
+
+private:
+    char peek() const;
+    char advance();
+    bool match(char expected);
+    void skipWhitespace();
+    Token makeToken(TokenType type, const std::string &lexeme);
+
+    const std::string &source;
+    size_t current{0};
+};
+
+} // namespace mylang
+
+#endif // LEXER_HPP

--- a/compiler/include/parser.hpp
+++ b/compiler/include/parser.hpp
@@ -1,0 +1,40 @@
+#ifndef PARSER_HPP
+#define PARSER_HPP
+
+#include <memory>
+#include <vector>
+
+#include "ast.hpp"
+#include "token.hpp"
+
+namespace mylang {
+
+class Parser {
+public:
+    explicit Parser(const std::vector<Token> &toks);
+
+    std::unique_ptr<Program> parseProgram();
+
+private:
+    const Token &peek() const;
+    bool match(TokenType type);
+    bool check(TokenType type) const;
+    const Token &advance();
+
+    std::unique_ptr<FunctionDecl> parseFunction();
+    std::unique_ptr<BlockStmt> parseBlock();
+    StmtPtr parseStatement();
+    StmtPtr parseVarDecl();
+    StmtPtr parseReturn();
+    ExprPtr parseExpression();
+    ExprPtr parseTerm();
+    ExprPtr parseFactor();
+    ExprPtr parsePrimary();
+
+    const std::vector<Token> &tokens;
+    size_t current{0};
+};
+
+} // namespace mylang
+
+#endif // PARSER_HPP

--- a/compiler/include/token.hpp
+++ b/compiler/include/token.hpp
@@ -1,0 +1,33 @@
+#ifndef TOKEN_HPP
+#define TOKEN_HPP
+
+#include <string>
+
+namespace mylang {
+
+enum class TokenType {
+    // Single-character tokens
+    LEFT_PAREN, RIGHT_PAREN,
+    LEFT_BRACE, RIGHT_BRACE,
+    SEMICOLON,
+    PLUS, MINUS, STAR, SLASH,
+    EQUAL,
+
+    // Literals
+    IDENTIFIER, NUMBER, STRING,
+
+    // Keywords
+    KW_INT, KW_RETURN,
+
+    END_OF_FILE,
+    INVALID
+};
+
+struct Token {
+    TokenType type;
+    std::string lexeme;
+};
+
+} // namespace mylang
+
+#endif // TOKEN_HPP

--- a/compiler/src/ast.cpp
+++ b/compiler/src/ast.cpp
@@ -1,0 +1,65 @@
+#include "ast.hpp"
+#include <iostream>
+
+namespace mylang {
+
+static void indent(int level) {
+    for (int i = 0; i < level; ++i) std::cout << "  ";
+}
+
+void Program::dump(int indentLevel) const {
+    indent(indentLevel);
+    std::cout << "Program\n";
+    for (const auto &fn : functions) {
+        fn->dump(indentLevel + 1);
+    }
+}
+
+void FunctionDecl::dump(int indentLevel) const {
+    indent(indentLevel);
+    std::cout << "FunctionDecl " << name << "\n";
+    if (body) body->dump(indentLevel + 1);
+}
+
+void BlockStmt::dump(int indentLevel) const {
+    indent(indentLevel);
+    std::cout << "BlockStmt\n";
+    for (const auto &stmt : statements) {
+        stmt->dump(indentLevel + 1);
+    }
+}
+
+void VarDecl::dump(int indentLevel) const {
+    indent(indentLevel);
+    std::cout << "VarDecl " << name << "\n";
+    if (init) init->dump(indentLevel + 1);
+}
+
+void ReturnStmt::dump(int indentLevel) const {
+    indent(indentLevel);
+    std::cout << "ReturnStmt\n";
+    if (value) value->dump(indentLevel + 1);
+}
+
+void ExprStmt::dump(int indentLevel) const {
+    if (expr) expr->dump(indentLevel);
+}
+
+void BinaryExpr::dump(int indentLevel) const {
+    indent(indentLevel);
+    std::cout << "BinaryExpr '" << op << "'\n";
+    if (left) left->dump(indentLevel + 1);
+    if (right) right->dump(indentLevel + 1);
+}
+
+void Identifier::dump(int indentLevel) const {
+    indent(indentLevel);
+    std::cout << "Identifier " << name << "\n";
+}
+
+void Literal::dump(int indentLevel) const {
+    indent(indentLevel);
+    std::cout << "Literal " << value << "\n";
+}
+
+} // namespace mylang

--- a/compiler/src/lexer.cpp
+++ b/compiler/src/lexer.cpp
@@ -1,0 +1,84 @@
+#include "lexer.hpp"
+#include <cctype>
+
+namespace mylang {
+
+Lexer::Lexer(const std::string &src) : source(src) {}
+
+char Lexer::peek() const {
+    if (current >= source.size()) return '\0';
+    return source[current];
+}
+
+char Lexer::advance() {
+    if (current >= source.size()) return '\0';
+    return source[current++];
+}
+
+bool Lexer::match(char expected) {
+    if (peek() == expected) {
+        current++;
+        return true;
+    }
+    return false;
+}
+
+void Lexer::skipWhitespace() {
+    while (std::isspace(peek())) {
+        current++;
+    }
+}
+
+Token Lexer::makeToken(TokenType type, const std::string &lexeme) {
+    return Token{type, lexeme};
+}
+
+std::vector<Token> Lexer::tokenize() {
+    std::vector<Token> tokens;
+
+    while (current < source.size()) {
+        skipWhitespace();
+        if (current >= source.size()) break;
+        char c = peek();
+        size_t start = current;
+
+        if (std::isalpha(c) || c == '_') {
+            while (std::isalnum(peek()) || peek() == '_') advance();
+            std::string text = source.substr(start, current - start);
+            if (text == "int") {
+                tokens.push_back(makeToken(TokenType::KW_INT, text));
+            } else if (text == "return") {
+                tokens.push_back(makeToken(TokenType::KW_RETURN, text));
+            } else {
+                tokens.push_back(makeToken(TokenType::IDENTIFIER, text));
+            }
+            continue;
+        }
+
+        if (std::isdigit(c)) {
+            while (std::isdigit(peek())) advance();
+            std::string text = source.substr(start, current - start);
+            tokens.push_back(makeToken(TokenType::NUMBER, text));
+            continue;
+        }
+
+        switch (advance()) {
+            case '(': tokens.push_back(makeToken(TokenType::LEFT_PAREN, "(")); break;
+            case ')': tokens.push_back(makeToken(TokenType::RIGHT_PAREN, ")")); break;
+            case '{': tokens.push_back(makeToken(TokenType::LEFT_BRACE, "{")); break;
+            case '}': tokens.push_back(makeToken(TokenType::RIGHT_BRACE, "}")); break;
+            case ';': tokens.push_back(makeToken(TokenType::SEMICOLON, ";")); break;
+            case '+': tokens.push_back(makeToken(TokenType::PLUS, "+")); break;
+            case '-': tokens.push_back(makeToken(TokenType::MINUS, "-")); break;
+            case '*': tokens.push_back(makeToken(TokenType::STAR, "*")); break;
+            case '/': tokens.push_back(makeToken(TokenType::SLASH, "/")); break;
+            case '=': tokens.push_back(makeToken(TokenType::EQUAL, "=")); break;
+            default: tokens.push_back(makeToken(TokenType::INVALID, std::string(1, c))); break;
+        }
+    }
+
+    tokens.push_back(makeToken(TokenType::END_OF_FILE, ""));
+    return tokens;
+}
+
+} // namespace mylang

--- a/compiler/src/main.cpp
+++ b/compiler/src/main.cpp
@@ -1,0 +1,31 @@
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include "lexer.hpp"
+#include "parser.hpp"
+
+using namespace mylang;
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <source file>\n";
+        return 1;
+    }
+    std::ifstream file(argv[1]);
+    if (!file) {
+        std::cerr << "Could not open file: " << argv[1] << "\n";
+        return 1;
+    }
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    std::string source = buffer.str();
+
+    Lexer lexer(source);
+    auto tokens = lexer.tokenize();
+
+    Parser parser(tokens);
+    auto program = parser.parseProgram();
+    program->dump();
+
+    return 0;
+}

--- a/compiler/src/parser.cpp
+++ b/compiler/src/parser.cpp
@@ -1,0 +1,142 @@
+#include "parser.hpp"
+#include <iostream>
+
+namespace mylang {
+
+Parser::Parser(const std::vector<Token> &toks) : tokens(toks) {}
+
+const Token &Parser::peek() const {
+    if (current >= tokens.size()) return tokens.back();
+    return tokens[current];
+}
+
+bool Parser::check(TokenType type) const {
+    return peek().type == type;
+}
+
+const Token &Parser::advance() {
+    if (current < tokens.size()) ++current;
+    return tokens[current - 1];
+}
+
+bool Parser::match(TokenType type) {
+    if (check(type)) { advance(); return true; }
+    return false;
+}
+
+std::unique_ptr<Program> Parser::parseProgram() {
+    auto program = std::make_unique<Program>();
+    while (!check(TokenType::END_OF_FILE)) {
+        program->functions.push_back(parseFunction());
+    }
+    return program;
+}
+
+std::unique_ptr<FunctionDecl> Parser::parseFunction() {
+    // assuming return type already matched "int"
+    match(TokenType::KW_INT);
+    std::string name = advance().lexeme; // identifier
+    match(TokenType::LEFT_PAREN); // (
+    match(TokenType::RIGHT_PAREN); // )
+    auto body = parseBlock();
+    auto fn = std::make_unique<FunctionDecl>();
+    fn->name = name;
+    fn->body = std::move(body);
+    return fn;
+}
+
+std::unique_ptr<BlockStmt> Parser::parseBlock() {
+    auto block = std::make_unique<BlockStmt>();
+    match(TokenType::LEFT_BRACE);
+    while (!check(TokenType::RIGHT_BRACE) && !check(TokenType::END_OF_FILE)) {
+        block->statements.push_back(parseStatement());
+    }
+    match(TokenType::RIGHT_BRACE);
+    return block;
+}
+
+StmtPtr Parser::parseStatement() {
+    if (check(TokenType::KW_INT)) return parseVarDecl();
+    if (check(TokenType::KW_RETURN)) return parseReturn();
+    // expression statement
+    auto stmt = std::make_unique<ExprStmt>();
+    stmt->expr = parseExpression();
+    match(TokenType::SEMICOLON);
+    return stmt;
+}
+
+StmtPtr Parser::parseVarDecl() {
+    match(TokenType::KW_INT);
+    std::string name = advance().lexeme; // identifier
+    auto decl = std::make_unique<VarDecl>();
+    decl->name = name;
+    if (match(TokenType::EQUAL)) {
+        decl->init = parseExpression();
+    }
+    match(TokenType::SEMICOLON);
+    return decl;
+}
+
+StmtPtr Parser::parseReturn() {
+    match(TokenType::KW_RETURN);
+    auto ret = std::make_unique<ReturnStmt>();
+    ret->value = parseExpression();
+    match(TokenType::SEMICOLON);
+    return ret;
+}
+
+ExprPtr Parser::parseExpression() {
+    return parseTerm();
+}
+
+ExprPtr Parser::parseTerm() {
+    auto expr = parseFactor();
+    while (check(TokenType::PLUS) || check(TokenType::MINUS)) {
+        std::string op = advance().lexeme;
+        auto right = parseFactor();
+        auto bin = std::make_unique<BinaryExpr>();
+        bin->op = op;
+        bin->left = std::move(expr);
+        bin->right = std::move(right);
+        expr = std::move(bin);
+    }
+    return expr;
+}
+
+ExprPtr Parser::parseFactor() {
+    auto expr = parsePrimary();
+    while (check(TokenType::STAR) || check(TokenType::SLASH)) {
+        std::string op = advance().lexeme;
+        auto right = parsePrimary();
+        auto bin = std::make_unique<BinaryExpr>();
+        bin->op = op;
+        bin->left = std::move(expr);
+        bin->right = std::move(right);
+        expr = std::move(bin);
+    }
+    return expr;
+}
+
+ExprPtr Parser::parsePrimary() {
+    if (match(TokenType::NUMBER)) {
+        auto lit = std::make_unique<Literal>();
+        lit->value = tokens[current - 1].lexeme;
+        return lit;
+    }
+    if (match(TokenType::IDENTIFIER)) {
+        auto id = std::make_unique<Identifier>();
+        id->name = tokens[current - 1].lexeme;
+        return id;
+    }
+    if (match(TokenType::LEFT_PAREN)) {
+        auto expr = parseExpression();
+        match(TokenType::RIGHT_PAREN);
+        return expr;
+    }
+    // fallback invalid
+    auto lit = std::make_unique<Literal>();
+    lit->value = "<invalid>";
+    return lit;
+}
+
+} // namespace mylang


### PR DESCRIPTION
## Summary
- implement AST node classes and dump helpers
- add recursive-descent parser for basic statements and expressions
- fix lexer to avoid spurious INVALID token at EOF
- update main program to parse source and dump AST

## Testing
- `make -C compiler`
- ran `./compiler/compiler sample.my` to verify AST output


------
https://chatgpt.com/codex/tasks/task_e_6843cd1d7af88324bc8c58104a73e696