### PR TITLE
Add semantic analyzer and type tracking

### DIFF
--- a/compiler/include/ast.hpp
+++ b/compiler/include/ast.hpp
@@ -1,9 +1,86 @@
 #ifndef AST_HPP
 #define AST_HPP
 
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
 namespace mylang {
 
-// AST node definitions will be added later
+// Base AST node
+struct ASTNode {
+    virtual ~ASTNode() = default;
+    virtual void dump(std::ostream &os, int indent = 0) const = 0;
+};
+
+enum class Type { Int, Float, String, Void };
+
+// Forward declarations
+struct Stmt;
+struct Expr;
+
+// Program node
+struct Program : ASTNode {
+    std::vector<std::unique_ptr<ASTNode>> decls; // functions or globals
+    void dump(std::ostream &os, int indent = 0) const override;
+};
+
+// Function declaration
+struct FunctionDecl : ASTNode {
+    std::string name;
+    Type returnType{Type::Void};
+    std::unique_ptr<Stmt> body; // BlockStmt
+    void dump(std::ostream &os, int indent = 0) const override;
+};
+
+// Statements
+struct Stmt : ASTNode {};
+
+struct BlockStmt : Stmt {
+    std::vector<std::unique_ptr<Stmt>> statements;
+    void dump(std::ostream &os, int indent = 0) const override;
+};
+
+struct VarDecl : Stmt {
+    std::string name;
+    Type varType{Type::Int};
+    std::unique_ptr<Expr> init;
+    void dump(std::ostream &os, int indent = 0) const override;
+};
+
+struct ReturnStmt : Stmt {
+    std::unique_ptr<Expr> value;
+    void dump(std::ostream &os, int indent = 0) const override;
+};
+
+struct ExprStmt : Stmt {
+    std::unique_ptr<Expr> expr;
+    void dump(std::ostream &os, int indent = 0) const override;
+};
+
+// Expressions
+struct Expr : ASTNode {};
+
+enum class BinaryOp { Add, Sub, Mul, Div };
+
+struct BinaryExpr : Expr {
+    BinaryOp op;
+    std::unique_ptr<Expr> left;
+    std::unique_ptr<Expr> right;
+    void dump(std::ostream &os, int indent = 0) const override;
+};
+
+struct Identifier : Expr {
+    std::string name;
+    void dump(std::ostream &os, int indent = 0) const override;
+};
+
+struct Literal : Expr {
+    std::string value;
+    Type litType{Type::Int};
+    void dump(std::ostream &os, int indent = 0) const override;
+};
 
 } // namespace mylang
 

--- a/compiler/include/parser.hpp
+++ b/compiler/include/parser.hpp
@@ -1,10 +1,38 @@
 #ifndef PARSER_HPP
 #define PARSER_HPP
 
+#include "ast.hpp"
+#include "token.hpp"
+
 namespace mylang {
 
 class Parser {
-    // Parser implementation will go here
+public:
+    explicit Parser(const std::vector<Token> &tokens);
+
+    std::unique_ptr<Program> parseProgram();
+
+private:
+    const std::vector<Token> &tokens;
+    size_t current{0};
+
+    const Token &peek() const;
+    const Token &previous() const;
+    bool match(TokenType type);
+    bool check(TokenType type) const;
+    const Token &advance();
+    bool isAtEnd() const;
+
+    std::unique_ptr<FunctionDecl> parseFunction();
+    std::unique_ptr<Stmt> parseStatement();
+    std::unique_ptr<Stmt> parseVarDecl();
+    std::unique_ptr<Stmt> parseReturn();
+    std::unique_ptr<Stmt> parseExprStmt();
+    std::unique_ptr<BlockStmt> parseBlock();
+    std::unique_ptr<Expr> parseExpression();
+    std::unique_ptr<Expr> parseAdd();
+    std::unique_ptr<Expr> parseMul();
+    std::unique_ptr<Expr> parsePrimary();
 };
 
 } // namespace mylang

--- a/compiler/include/semantic.hpp
+++ b/compiler/include/semantic.hpp
@@ -1,0 +1,33 @@
+#ifndef SEMANTIC_HPP
+#define SEMANTIC_HPP
+
+#include "ast.hpp"
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace mylang {
+
+class SemanticAnalyzer {
+public:
+    bool analyze(Program &program);
+
+private:
+    std::vector<std::unordered_map<std::string, Type>> scopes;
+    Type currentReturn{Type::Void};
+    bool hasError{false};
+
+    void pushScope();
+    void popScope();
+    void error(const std::string &msg);
+
+    void visitFunction(FunctionDecl &fn);
+    void visitBlock(BlockStmt &block);
+    void visitStmt(Stmt &stmt);
+    Type visitExpr(Expr &expr);
+    Type lookup(const std::string &name);
+};
+
+} // namespace mylang
+
+#endif // SEMANTIC_HPP

--- a/compiler/include/token.hpp
+++ b/compiler/include/token.hpp
@@ -18,6 +18,7 @@ enum class TokenType {
 
     // Keywords
     KW_INT, KW_RETURN,
+    KW_IF, KW_WHILE,
 
     END_OF_FILE,
     INVALID

--- a/compiler/src/lexer.cpp
+++ b/compiler/src/lexer.cpp
@@ -38,6 +38,7 @@ std::vector<Token> Lexer::tokenize() {
 
     while (current < source.size()) {
         skipWhitespace();
+        if (current >= source.size()) break;
         char c = peek();
         size_t start = current;
 
@@ -48,9 +49,22 @@ std::vector<Token> Lexer::tokenize() {
                 tokens.push_back(makeToken(TokenType::KW_INT, text));
             } else if (text == "return") {
                 tokens.push_back(makeToken(TokenType::KW_RETURN, text));
+            } else if (text == "if") {
+                tokens.push_back(makeToken(TokenType::KW_IF, text));
+            } else if (text == "while") {
+                tokens.push_back(makeToken(TokenType::KW_WHILE, text));
             } else {
                 tokens.push_back(makeToken(TokenType::IDENTIFIER, text));
             }
+            continue;
+        }
+
+        if (c == '"') {
+            advance();
+            while (peek() != '"' && current < source.size()) advance();
+            std::string text = source.substr(start + 1, current - start - 1);
+            match('"');
+            tokens.push_back(makeToken(TokenType::STRING, text));
             continue;
         }
 

--- a/compiler/src/main.cpp
+++ b/compiler/src/main.cpp
@@ -2,6 +2,8 @@
 #include <iostream>
 #include <sstream>
 #include "lexer.hpp"
+#include "parser.hpp"
+#include "semantic.hpp"
 
 using namespace mylang;
 
@@ -22,9 +24,16 @@ int main(int argc, char **argv) {
     Lexer lexer(source);
     auto tokens = lexer.tokenize();
 
-    for (const auto &tok : tokens) {
-        std::cout << static_cast<int>(tok.type) << "\t" << tok.lexeme << "\n";
+    Parser parser(tokens);
+    auto program = parser.parseProgram();
+
+    SemanticAnalyzer analyzer;
+    if (!analyzer.analyze(*program)) {
+        std::cerr << "Semantic analysis failed\n";
+        return 1;
     }
+
+    program->dump(std::cout);
 
     return 0;
 }

--- a/compiler/src/parser.cpp
+++ b/compiler/src/parser.cpp
@@ -1,5 +1,234 @@
 #include "parser.hpp"
+#include <iostream>
 
 namespace mylang {
-// Parser implementation will be added later
+
+Parser::Parser(const std::vector<Token> &toks) : tokens(toks) {}
+
+const Token &Parser::peek() const { return tokens[current]; }
+const Token &Parser::previous() const { return tokens[current - 1]; }
+
+bool Parser::isAtEnd() const { return peek().type == TokenType::END_OF_FILE; }
+
+const Token &Parser::advance() {
+    if (!isAtEnd()) current++;
+    return previous();
 }
+
+bool Parser::check(TokenType type) const {
+    if (isAtEnd()) return false;
+    return peek().type == type;
+}
+
+bool Parser::match(TokenType type) {
+    if (check(type)) { advance(); return true; }
+    return false;
+}
+
+std::unique_ptr<Program> Parser::parseProgram() {
+    auto program = std::make_unique<Program>();
+    while (!isAtEnd()) {
+        program->decls.push_back(parseFunction());
+    }
+    return program;
+}
+
+std::unique_ptr<FunctionDecl> Parser::parseFunction() {
+    match(TokenType::KW_INT); // only int for now
+    Token nameTok = advance(); // identifier
+    match(TokenType::LEFT_PAREN);
+    match(TokenType::RIGHT_PAREN);
+    auto body = parseBlock();
+    auto fn = std::make_unique<FunctionDecl>();
+    fn->name = nameTok.lexeme;
+    fn->returnType = Type::Int;
+    fn->body = std::move(body);
+    return fn;
+}
+
+std::unique_ptr<BlockStmt> Parser::parseBlock() {
+    match(TokenType::LEFT_BRACE);
+    auto block = std::make_unique<BlockStmt>();
+    while (!check(TokenType::RIGHT_BRACE) && !isAtEnd()) {
+        block->statements.push_back(parseStatement());
+    }
+    match(TokenType::RIGHT_BRACE);
+    return block;
+}
+
+std::unique_ptr<Stmt> Parser::parseStatement() {
+    if (check(TokenType::KW_INT)) return parseVarDecl();
+    if (check(TokenType::KW_RETURN)) return parseReturn();
+    return parseExprStmt();
+}
+
+std::unique_ptr<Stmt> Parser::parseVarDecl() {
+    match(TokenType::KW_INT);
+    Token nameTok = advance(); // identifier
+    std::unique_ptr<Expr> init;
+    if (match(TokenType::EQUAL)) {
+        init = parseExpression();
+    }
+    match(TokenType::SEMICOLON);
+    auto decl = std::make_unique<VarDecl>();
+    decl->name = nameTok.lexeme;
+    decl->varType = Type::Int;
+    decl->init = std::move(init);
+    return decl;
+}
+
+std::unique_ptr<Stmt> Parser::parseReturn() {
+    match(TokenType::KW_RETURN);
+    auto value = parseExpression();
+    match(TokenType::SEMICOLON);
+    auto stmt = std::make_unique<ReturnStmt>();
+    stmt->value = std::move(value);
+    return stmt;
+}
+
+std::unique_ptr<Stmt> Parser::parseExprStmt() {
+    auto expr = parseExpression();
+    match(TokenType::SEMICOLON);
+    auto stmt = std::make_unique<ExprStmt>();
+    stmt->expr = std::move(expr);
+    return stmt;
+}
+
+std::unique_ptr<Expr> Parser::parseExpression() { return parseAdd(); }
+
+std::unique_ptr<Expr> Parser::parseAdd() {
+    auto expr = parseMul();
+    while (match(TokenType::PLUS) || match(TokenType::MINUS)) {
+        Token opTok = previous();
+        auto right = parseMul();
+        auto bin = std::make_unique<BinaryExpr>();
+        bin->left = std::move(expr);
+        bin->right = std::move(right);
+        bin->op = (opTok.type == TokenType::PLUS) ? BinaryOp::Add : BinaryOp::Sub;
+        expr = std::move(bin);
+    }
+    return expr;
+}
+
+std::unique_ptr<Expr> Parser::parseMul() {
+    auto expr = parsePrimary();
+    while (match(TokenType::STAR) || match(TokenType::SLASH)) {
+        Token opTok = previous();
+        auto right = parsePrimary();
+        auto bin = std::make_unique<BinaryExpr>();
+        bin->left = std::move(expr);
+        bin->right = std::move(right);
+        bin->op = (opTok.type == TokenType::STAR) ? BinaryOp::Mul : BinaryOp::Div;
+        expr = std::move(bin);
+    }
+    return expr;
+}
+
+std::unique_ptr<Expr> Parser::parsePrimary() {
+    if (match(TokenType::NUMBER)) {
+        auto lit = std::make_unique<Literal>();
+        lit->value = previous().lexeme;
+        lit->litType = Type::Int;
+        return lit;
+    }
+    if (match(TokenType::STRING)) {
+        auto lit = std::make_unique<Literal>();
+        lit->value = previous().lexeme;
+        lit->litType = Type::String;
+        return lit;
+    }
+    if (match(TokenType::IDENTIFIER)) {
+        auto id = std::make_unique<Identifier>();
+        id->name = previous().lexeme;
+        return id;
+    }
+    if (match(TokenType::LEFT_PAREN)) {
+        auto expr = parseExpression();
+        match(TokenType::RIGHT_PAREN);
+        return expr;
+    }
+    // Fallback literal
+    auto invalid = std::make_unique<Literal>();
+    invalid->value = "";
+    return invalid;
+}
+
+// AST dump implementations
+static void printIndent(std::ostream &os, int level) {
+    for (int i = 0; i < level; ++i) os << ' ';
+}
+
+void Program::dump(std::ostream &os, int indent) const {
+    printIndent(os, indent); os << "Program\n";
+    for (const auto &d : decls) d->dump(os, indent + 2);
+}
+
+void FunctionDecl::dump(std::ostream &os, int indent) const {
+    printIndent(os, indent); os << "FunctionDecl " << name << " (";
+    switch (returnType) {
+        case Type::Int: os << "int"; break;
+        case Type::Float: os << "float"; break;
+        case Type::String: os << "string"; break;
+        case Type::Void: os << "void"; break;
+    }
+    os << ")\n";
+    if (body) body->dump(os, indent + 2);
+}
+
+void BlockStmt::dump(std::ostream &os, int indent) const {
+    printIndent(os, indent); os << "BlockStmt\n";
+    for (const auto &s : statements) s->dump(os, indent + 2);
+}
+
+void VarDecl::dump(std::ostream &os, int indent) const {
+    printIndent(os, indent); os << "VarDecl " << name << " : ";
+    switch (varType) {
+        case Type::Int: os << "int"; break;
+        case Type::Float: os << "float"; break;
+        case Type::String: os << "string"; break;
+        case Type::Void: os << "void"; break;
+    }
+    os << "\n";
+    if (init) init->dump(os, indent + 2);
+}
+
+void ReturnStmt::dump(std::ostream &os, int indent) const {
+    printIndent(os, indent); os << "ReturnStmt\n";
+    if (value) value->dump(os, indent + 2);
+}
+
+void ExprStmt::dump(std::ostream &os, int indent) const {
+    printIndent(os, indent); os << "ExprStmt\n";
+    if (expr) expr->dump(os, indent + 2);
+}
+
+void BinaryExpr::dump(std::ostream &os, int indent) const {
+    printIndent(os, indent); os << "BinaryExpr";
+    switch (op) {
+        case BinaryOp::Add: os << " +"; break;
+        case BinaryOp::Sub: os << " -"; break;
+        case BinaryOp::Mul: os << " *"; break;
+        case BinaryOp::Div: os << " /"; break;
+    }
+    os << "\n";
+    if (left) left->dump(os, indent + 2);
+    if (right) right->dump(os, indent + 2);
+}
+
+void Identifier::dump(std::ostream &os, int indent) const {
+    printIndent(os, indent); os << "Identifier " << name << "\n";
+}
+
+void Literal::dump(std::ostream &os, int indent) const {
+    printIndent(os, indent); os << "Literal " << value << " : ";
+    switch (litType) {
+        case Type::Int: os << "int"; break;
+        case Type::Float: os << "float"; break;
+        case Type::String: os << "string"; break;
+        case Type::Void: os << "void"; break;
+    }
+    os << "\n";
+}
+
+} // namespace mylang
+

--- a/compiler/src/semantic.cpp
+++ b/compiler/src/semantic.cpp
@@ -1,0 +1,99 @@
+#include "semantic.hpp"
+#include <iostream>
+
+namespace mylang {
+
+void SemanticAnalyzer::pushScope() { scopes.emplace_back(); }
+void SemanticAnalyzer::popScope() { scopes.pop_back(); }
+
+void SemanticAnalyzer::error(const std::string &msg) {
+    std::cerr << "Semantic error: " << msg << "\n";
+    hasError = true;
+}
+
+Type SemanticAnalyzer::lookup(const std::string &name) {
+    for (auto it = scopes.rbegin(); it != scopes.rend(); ++it) {
+        auto found = it->find(name);
+        if (found != it->end()) return found->second;
+    }
+    error("undeclared identifier " + name);
+    return Type::Int;
+}
+
+void SemanticAnalyzer::visitFunction(FunctionDecl &fn) {
+    currentReturn = fn.returnType;
+    pushScope();
+    if (auto *body = dynamic_cast<BlockStmt*>(fn.body.get())) {
+        visitBlock(*body);
+    }
+    popScope();
+}
+
+void SemanticAnalyzer::visitBlock(BlockStmt &block) {
+    pushScope();
+    for (auto &stmt : block.statements) {
+        visitStmt(*stmt);
+    }
+    popScope();
+}
+
+void SemanticAnalyzer::visitStmt(Stmt &stmt) {
+    if (auto *vd = dynamic_cast<VarDecl*>(&stmt)) {
+        auto &scope = scopes.back();
+        if (scope.count(vd->name)) {
+            error("redeclared variable " + vd->name);
+        } else {
+            scope[vd->name] = vd->varType;
+        }
+        if (vd->init) {
+            Type initTy = visitExpr(*vd->init);
+            if (initTy != vd->varType) {
+                error("type mismatch in initialization of " + vd->name);
+            }
+        }
+    } else if (auto *ret = dynamic_cast<ReturnStmt*>(&stmt)) {
+        if (ret->value) {
+            Type valTy = visitExpr(*ret->value);
+            if (valTy != currentReturn) {
+                error("return type mismatch");
+            }
+        } else if (currentReturn != Type::Void) {
+            error("non-void function must return a value");
+        }
+    } else if (auto *es = dynamic_cast<ExprStmt*>(&stmt)) {
+        if (es->expr) visitExpr(*es->expr);
+    } else if (auto *blk = dynamic_cast<BlockStmt*>(&stmt)) {
+        visitBlock(*blk);
+    }
+}
+
+Type SemanticAnalyzer::visitExpr(Expr &expr) {
+    if (auto *id = dynamic_cast<Identifier*>(&expr)) {
+        return lookup(id->name);
+    }
+    if (auto *lit = dynamic_cast<Literal*>(&expr)) {
+        return lit->litType;
+    }
+    if (auto *bin = dynamic_cast<BinaryExpr*>(&expr)) {
+        Type lt = visitExpr(*bin->left);
+        Type rt = visitExpr(*bin->right);
+        if (lt != rt) {
+            error("type mismatch in binary expression");
+        }
+        return lt;
+    }
+    return Type::Int;
+}
+
+bool SemanticAnalyzer::analyze(Program &program) {
+    pushScope();
+    for (auto &decl : program.decls) {
+        if (auto *fn = dynamic_cast<FunctionDecl*>(decl.get())) {
+            visitFunction(*fn);
+        }
+    }
+    popScope();
+    return !hasError;
+}
+
+} // namespace mylang


### PR DESCRIPTION
## Summary
- track simple types in AST nodes
- extend lexer and parser for string literals
- implement `SemanticAnalyzer` to validate declarations and returns
- run semantic analysis from `main.cpp`

## Testing
- `make -C compiler`
- `./compiler/compiler sample.my` (int return)  
- `./compiler/compiler sample_err.my` (string return)

------
https://chatgpt.com/codex/tasks/task_e_6843d059ade08324add2172350e12c71