### PR TITLE
Track line and column for tokens

### DIFF
--- a/compiler/include/lexer.hpp
+++ b/compiler/include/lexer.hpp
@@ -17,10 +17,12 @@ private:
     char advance();
     bool match(char expected);
     void skipWhitespace();
-    Token makeToken(TokenType type, const std::string &lexeme);
+    Token makeToken(TokenType type, const std::string &lexeme, int line, int column);
 
     const std::string &source;
     size_t current{0};
+    int line{1};
+    int column{1};
 };
 
 } // namespace mylang

--- a/compiler/include/token.hpp
+++ b/compiler/include/token.hpp
@@ -28,6 +28,8 @@ enum class TokenType {
 struct Token {
     TokenType type;
     std::string lexeme;
+    int line{0};
+    int column{0};
 };
 
 } // namespace mylang

--- a/compiler/src/lexer.cpp
+++ b/compiler/src/lexer.cpp
@@ -12,12 +12,19 @@ char Lexer::peek() const {
 
 char Lexer::advance() {
     if (current >= source.size()) return '\0';
-    return source[current++];
+    char c = source[current++];
+    if (c == '\n') {
+        line++;
+        column = 1;
+    } else {
+        column++;
+    }
+    return c;
 }
 
 bool Lexer::match(char expected) {
     if (peek() == expected) {
-        current++;
+        advance();
         return true;
     }
     return false;
@@ -25,12 +32,12 @@ bool Lexer::match(char expected) {
 
 void Lexer::skipWhitespace() {
     while (std::isspace(peek())) {
-        current++;
+        advance();
     }
 }
 
-Token Lexer::makeToken(TokenType type, const std::string &lexeme) {
-    return Token{type, lexeme};
+Token Lexer::makeToken(TokenType type, const std::string &lexeme, int tokLine, int tokColumn) {
+    return Token{type, lexeme, tokLine, tokColumn};
 }
 
 std::vector<Token> Lexer::tokenize() {
@@ -39,6 +46,8 @@ std::vector<Token> Lexer::tokenize() {
     while (current < source.size()) {
         skipWhitespace();
         if (current >= source.size()) break;
+        int tokLine = line;
+        int tokCol = column;
         char c = peek();
         size_t start = current;
 
@@ -46,21 +55,21 @@ std::vector<Token> Lexer::tokenize() {
             while (std::isalnum(peek()) || peek() == '_') advance();
             std::string text = source.substr(start, current - start);
             if (text == "int") {
-                tokens.push_back(makeToken(TokenType::KW_INT, text));
+                tokens.push_back(makeToken(TokenType::KW_INT, text, tokLine, tokCol));
             } else if (text == "float") {
-                tokens.push_back(makeToken(TokenType::KW_FLOAT, text));
+                tokens.push_back(makeToken(TokenType::KW_FLOAT, text, tokLine, tokCol));
             } else if (text == "string") {
-                tokens.push_back(makeToken(TokenType::KW_STRING, text));
+                tokens.push_back(makeToken(TokenType::KW_STRING, text, tokLine, tokCol));
             } else if (text == "void") {
-                tokens.push_back(makeToken(TokenType::KW_VOID, text));
+                tokens.push_back(makeToken(TokenType::KW_VOID, text, tokLine, tokCol));
             } else if (text == "return") {
-                tokens.push_back(makeToken(TokenType::KW_RETURN, text));
+                tokens.push_back(makeToken(TokenType::KW_RETURN, text, tokLine, tokCol));
             } else if (text == "if") {
-                tokens.push_back(makeToken(TokenType::KW_IF, text));
+                tokens.push_back(makeToken(TokenType::KW_IF, text, tokLine, tokCol));
             } else if (text == "while") {
-                tokens.push_back(makeToken(TokenType::KW_WHILE, text));
+                tokens.push_back(makeToken(TokenType::KW_WHILE, text, tokLine, tokCol));
             } else {
-                tokens.push_back(makeToken(TokenType::IDENTIFIER, text));
+                tokens.push_back(makeToken(TokenType::IDENTIFIER, text, tokLine, tokCol));
             }
             continue;
         }
@@ -68,26 +77,26 @@ std::vector<Token> Lexer::tokenize() {
         if (std::isdigit(c)) {
             while (std::isdigit(peek())) advance();
             std::string text = source.substr(start, current - start);
-            tokens.push_back(makeToken(TokenType::NUMBER, text));
+            tokens.push_back(makeToken(TokenType::NUMBER, text, tokLine, tokCol));
             continue;
         }
 
         switch (advance()) {
-            case '(': tokens.push_back(makeToken(TokenType::LEFT_PAREN, "(")); break;
-            case ')': tokens.push_back(makeToken(TokenType::RIGHT_PAREN, ")")); break;
-            case '{': tokens.push_back(makeToken(TokenType::LEFT_BRACE, "{")); break;
-            case '}': tokens.push_back(makeToken(TokenType::RIGHT_BRACE, "}")); break;
-            case ';': tokens.push_back(makeToken(TokenType::SEMICOLON, ";")); break;
-            case '+': tokens.push_back(makeToken(TokenType::PLUS, "+")); break;
-            case '-': tokens.push_back(makeToken(TokenType::MINUS, "-")); break;
-            case '*': tokens.push_back(makeToken(TokenType::STAR, "*")); break;
-            case '/': tokens.push_back(makeToken(TokenType::SLASH, "/")); break;
-            case '=': tokens.push_back(makeToken(TokenType::EQUAL, "=")); break;
-            default: tokens.push_back(makeToken(TokenType::INVALID, std::string(1, c))); break;
+            case '(': tokens.push_back(makeToken(TokenType::LEFT_PAREN, "(", tokLine, tokCol)); break;
+            case ')': tokens.push_back(makeToken(TokenType::RIGHT_PAREN, ")", tokLine, tokCol)); break;
+            case '{': tokens.push_back(makeToken(TokenType::LEFT_BRACE, "{", tokLine, tokCol)); break;
+            case '}': tokens.push_back(makeToken(TokenType::RIGHT_BRACE, "}", tokLine, tokCol)); break;
+            case ';': tokens.push_back(makeToken(TokenType::SEMICOLON, ";", tokLine, tokCol)); break;
+            case '+': tokens.push_back(makeToken(TokenType::PLUS, "+", tokLine, tokCol)); break;
+            case '-': tokens.push_back(makeToken(TokenType::MINUS, "-", tokLine, tokCol)); break;
+            case '*': tokens.push_back(makeToken(TokenType::STAR, "*", tokLine, tokCol)); break;
+            case '/': tokens.push_back(makeToken(TokenType::SLASH, "/", tokLine, tokCol)); break;
+            case '=': tokens.push_back(makeToken(TokenType::EQUAL, "=", tokLine, tokCol)); break;
+            default: tokens.push_back(makeToken(TokenType::INVALID, std::string(1, c), tokLine, tokCol)); break;
         }
     }
 
-    tokens.push_back(makeToken(TokenType::END_OF_FILE, ""));
+    tokens.push_back(makeToken(TokenType::END_OF_FILE, "", line, column));
     return tokens;
 }
 


### PR DESCRIPTION
## Summary
- add `line` and `column` fields to `Token`
- update `Lexer` to keep track of line/column when scanning
- pass the position to `makeToken`

## Testing
- `make -C compiler`


------
https://chatgpt.com/codex/tasks/task_e_6843d402b8488324b3287f98e570902a