### PR TITLE
Add string literal handling

### DIFF
--- a/compiler/include/lexer.hpp
+++ b/compiler/include/lexer.hpp
@@ -16,6 +16,7 @@ private:
     char peek() const;
     char advance();
     bool match(char expected);
+    Token lexString();
     void skipWhitespace();
     Token makeToken(TokenType type, const std::string &lexeme, int line, int column);
 

--- a/compiler/src/lexer.cpp
+++ b/compiler/src/lexer.cpp
@@ -30,6 +30,21 @@ bool Lexer::match(char expected) {
     return false;
 }
 
+Token Lexer::lexString() {
+    int tokLine = line;
+    int tokCol = column;
+    advance(); // consume opening quote
+    size_t start = current;
+    while (peek() != '"' && current < source.size()) {
+        advance();
+    }
+    std::string text = source.substr(start, current - start);
+    if (peek() == '"') {
+        advance();
+    }
+    return makeToken(TokenType::STRING, text, tokLine, tokCol);
+}
+
 void Lexer::skipWhitespace() {
     while (std::isspace(peek())) {
         advance();
@@ -78,6 +93,11 @@ std::vector<Token> Lexer::tokenize() {
             while (std::isdigit(peek())) advance();
             std::string text = source.substr(start, current - start);
             tokens.push_back(makeToken(TokenType::NUMBER, text, tokLine, tokCol));
+            continue;
+        }
+
+        if (c == '"') {
+            tokens.push_back(lexString());
             continue;
         }
 

--- a/compiler/src/parser.cpp
+++ b/compiler/src/parser.cpp
@@ -139,6 +139,11 @@ std::unique_ptr<Expr> Parser::parsePrimary() {
         lit->value = previous().lexeme;
         return lit;
     }
+    if (match(TokenType::STRING)) {
+        auto lit = std::make_unique<Literal>();
+        lit->value = previous().lexeme;
+        return lit;
+    }
     if (match(TokenType::IDENTIFIER)) {
         auto id = std::make_unique<Identifier>();
         id->name = previous().lexeme;


### PR DESCRIPTION
## Summary
- extend lexer with lexString helper to tokenize quoted strings
- parse string literals in `parsePrimary`

## Testing
- `make -C compiler`

------
https://chatgpt.com/codex/tasks/task_e_68450d25e3d08324ad2199bc89901283