### PR TITLE
Add basic semantic analyzer

### DIFF
--- a/compiler/include/ast.hpp
+++ b/compiler/include/ast.hpp
@@ -11,6 +11,9 @@ namespace mylang {
 
 // Base AST node
 struct ASTNode {
+    int line{0};
+    int column{0};
+
     virtual ~ASTNode() = default;
     virtual void dump(std::ostream &os, int indent = 0) const = 0;
 };

--- a/compiler/include/semantic_analyzer.hpp
+++ b/compiler/include/semantic_analyzer.hpp
@@ -1,0 +1,35 @@
+#ifndef SEMANTIC_ANALYZER_HPP
+#define SEMANTIC_ANALYZER_HPP
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "ast.hpp"
+
+namespace mylang {
+
+class SemanticAnalyzer {
+public:
+    bool analyze(const Program &program);
+
+private:
+    using Scope = std::unordered_map<std::string, Type>;
+    std::vector<Scope> scopes;
+    std::vector<std::string> diagnostics;
+
+    void pushScope();
+    void popScope();
+    bool lookup(const std::string &name, Type &out) const;
+    bool typesCompatible(Type a, Type b) const;
+    void addDiagnostic(int line, int column, const std::string &msg);
+
+    void analyzeProgram(const Program &program);
+    void analyzeFunction(const FunctionDecl &fn);
+    void analyzeStmt(const Stmt *stmt, Type expectedReturn);
+    Type analyzeExpr(const Expr *expr);
+};
+
+} // namespace mylang
+
+#endif // SEMANTIC_ANALYZER_HPP

--- a/compiler/src/parser.cpp
+++ b/compiler/src/parser.cpp
@@ -40,6 +40,8 @@ std::unique_ptr<FunctionDecl> Parser::parseFunction() {
     match(TokenType::RIGHT_PAREN);
     auto body = parseBlock();
     auto fn = std::make_unique<FunctionDecl>();
+    fn->line = nameTok.line;
+    fn->column = nameTok.column;
     fn->returnType = retType;
     fn->name = nameTok.lexeme;
     fn->body = std::move(body);
@@ -49,6 +51,8 @@ std::unique_ptr<FunctionDecl> Parser::parseFunction() {
 std::unique_ptr<BlockStmt> Parser::parseBlock() {
     match(TokenType::LEFT_BRACE);
     auto block = std::make_unique<BlockStmt>();
+    block->line = previous().line;
+    block->column = previous().column;
     while (!check(TokenType::RIGHT_BRACE) && !isAtEnd()) {
         block->statements.push_back(parseStatement());
     }
@@ -80,6 +84,8 @@ std::unique_ptr<Stmt> Parser::parseVarDecl() {
     }
     match(TokenType::SEMICOLON);
     auto decl = std::make_unique<VarDecl>();
+    decl->line = nameTok.line;
+    decl->column = nameTok.column;
     decl->varType = varType;
     decl->name = nameTok.lexeme;
     decl->init = std::move(init);
@@ -88,9 +94,12 @@ std::unique_ptr<Stmt> Parser::parseVarDecl() {
 
 std::unique_ptr<Stmt> Parser::parseReturn() {
     match(TokenType::KW_RETURN);
+    Token tok = previous();
     auto value = parseExpression();
     match(TokenType::SEMICOLON);
     auto stmt = std::make_unique<ReturnStmt>();
+    stmt->line = tok.line;
+    stmt->column = tok.column;
     stmt->value = std::move(value);
     return stmt;
 }
@@ -99,6 +108,8 @@ std::unique_ptr<Stmt> Parser::parseExprStmt() {
     auto expr = parseExpression();
     match(TokenType::SEMICOLON);
     auto stmt = std::make_unique<ExprStmt>();
+    stmt->line = expr ? expr->line : previous().line;
+    stmt->column = expr ? expr->column : previous().column;
     stmt->expr = std::move(expr);
     return stmt;
 }
@@ -111,6 +122,8 @@ std::unique_ptr<Expr> Parser::parseAdd() {
         Token opTok = previous();
         auto right = parseMul();
         auto bin = std::make_unique<BinaryExpr>();
+        bin->line = opTok.line;
+        bin->column = opTok.column;
         bin->left = std::move(expr);
         bin->right = std::move(right);
         bin->op = (opTok.type == TokenType::PLUS) ? BinaryOp::Add : BinaryOp::Sub;
@@ -125,6 +138,8 @@ std::unique_ptr<Expr> Parser::parseMul() {
         Token opTok = previous();
         auto right = parsePrimary();
         auto bin = std::make_unique<BinaryExpr>();
+        bin->line = opTok.line;
+        bin->column = opTok.column;
         bin->left = std::move(expr);
         bin->right = std::move(right);
         bin->op = (opTok.type == TokenType::STAR) ? BinaryOp::Mul : BinaryOp::Div;
@@ -135,18 +150,27 @@ std::unique_ptr<Expr> Parser::parseMul() {
 
 std::unique_ptr<Expr> Parser::parsePrimary() {
     if (match(TokenType::NUMBER)) {
+        Token tok = previous();
         auto lit = std::make_unique<Literal>();
-        lit->value = previous().lexeme;
+        lit->line = tok.line;
+        lit->column = tok.column;
+        lit->value = tok.lexeme;
         return lit;
     }
     if (match(TokenType::STRING)) {
+        Token tok = previous();
         auto lit = std::make_unique<Literal>();
-        lit->value = previous().lexeme;
+        lit->line = tok.line;
+        lit->column = tok.column;
+        lit->value = tok.lexeme;
         return lit;
     }
     if (match(TokenType::IDENTIFIER)) {
+        Token tok = previous();
         auto id = std::make_unique<Identifier>();
-        id->name = previous().lexeme;
+        id->line = tok.line;
+        id->column = tok.column;
+        id->name = tok.lexeme;
         return id;
     }
     if (match(TokenType::LEFT_PAREN)) {

--- a/compiler/src/semantic_analyzer.cpp
+++ b/compiler/src/semantic_analyzer.cpp
@@ -1,0 +1,107 @@
+#include "semantic_analyzer.hpp"
+
+#include <iostream>
+#include <sstream>
+
+namespace mylang {
+
+void SemanticAnalyzer::pushScope() { scopes.emplace_back(); }
+
+void SemanticAnalyzer::popScope() { if (!scopes.empty()) scopes.pop_back(); }
+
+bool SemanticAnalyzer::lookup(const std::string &name, Type &out) const {
+    for (auto it = scopes.rbegin(); it != scopes.rend(); ++it) {
+        auto f = it->find(name);
+        if (f != it->end()) { out = f->second; return true; }
+    }
+    return false;
+}
+
+bool SemanticAnalyzer::typesCompatible(Type a, Type b) const { return a == b; }
+
+void SemanticAnalyzer::addDiagnostic(int line, int column, const std::string &msg) {
+    std::ostringstream os;
+    os << "[" << line << ":" << column << "] " << msg;
+    diagnostics.push_back(os.str());
+}
+
+bool SemanticAnalyzer::analyze(const Program &program) {
+    diagnostics.clear();
+    pushScope();
+    analyzeProgram(program);
+    popScope();
+
+    for (const auto &d : diagnostics) {
+        std::cerr << d << '\n';
+    }
+    return diagnostics.empty();
+}
+
+void SemanticAnalyzer::analyzeProgram(const Program &program) {
+    for (const auto &decl : program.decls) {
+        if (auto fn = dynamic_cast<FunctionDecl*>(decl.get())) {
+            analyzeFunction(*fn);
+        }
+    }
+}
+
+void SemanticAnalyzer::analyzeFunction(const FunctionDecl &fn) {
+    pushScope();
+    if (fn.body) analyzeStmt(fn.body.get(), fn.returnType);
+    popScope();
+}
+
+void SemanticAnalyzer::analyzeStmt(const Stmt *stmt, Type expectedReturn) {
+    if (auto block = dynamic_cast<const BlockStmt*>(stmt)) {
+        pushScope();
+        for (const auto &s : block->statements) analyzeStmt(s.get(), expectedReturn);
+        popScope();
+    } else if (auto decl = dynamic_cast<const VarDecl*>(stmt)) {
+        Scope &scope = scopes.back();
+        if (scope.count(decl->name)) {
+            addDiagnostic(decl->line, decl->column, "redefinition of variable '" + decl->name + "'");
+        } else {
+            scope[decl->name] = decl->varType;
+        }
+        if (decl->init) {
+            Type initType = analyzeExpr(decl->init.get());
+            if (!typesCompatible(decl->varType, initType)) {
+                addDiagnostic(decl->init->line, decl->init->column, "type mismatch in initialization of '" + decl->name + "'");
+            }
+        }
+    } else if (auto ret = dynamic_cast<const ReturnStmt*>(stmt)) {
+        Type valType = Type::Void;
+        if (ret->value) valType = analyzeExpr(ret->value.get());
+        if (!typesCompatible(expectedReturn, valType)) {
+            addDiagnostic(ret->line, ret->column, "return type mismatch: expected " + std::string(typeToString(expectedReturn)));
+        }
+    } else if (auto exprStmt = dynamic_cast<const ExprStmt*>(stmt)) {
+        if (exprStmt->expr) analyzeExpr(exprStmt->expr.get());
+    }
+}
+
+Type SemanticAnalyzer::analyzeExpr(const Expr *expr) {
+    if (auto lit = dynamic_cast<const Literal*>(expr)) {
+        // crude literal type detection
+        bool isNumber = true;
+        for (char c : lit->value) if (!std::isdigit(c)) { isNumber = false; break; }
+        return isNumber ? Type::Int : Type::String;
+    } else if (auto id = dynamic_cast<const Identifier*>(expr)) {
+        Type t{};
+        if (!lookup(id->name, t)) {
+            addDiagnostic(id->line, id->column, "use of undeclared identifier '" + id->name + "'");
+            return Type::Int;
+        }
+        return t;
+    } else if (auto bin = dynamic_cast<const BinaryExpr*>(expr)) {
+        Type left = analyzeExpr(bin->left.get());
+        Type right = analyzeExpr(bin->right.get());
+        if (!typesCompatible(left, right)) {
+            addDiagnostic(bin->line, bin->column, "type mismatch in binary expression");
+        }
+        return left;
+    }
+    return Type::Int;
+}
+
+} // namespace mylang


### PR DESCRIPTION
## Summary
- extend AST nodes with source location data
- capture source location in parser
- add new SemanticAnalyzer class with scope tracking and simple type checks

## Testing
- `make clean`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68450dde124883249a65a7425001e81b